### PR TITLE
Pea/events omit non an events from sync

### DIFF
--- a/src/App/Admin/Notices.php
+++ b/src/App/Admin/Notices.php
@@ -77,6 +77,7 @@ class Notices extends Base {
 		 * @see Bootstrap::__construct
 		 */
 		$this->status = \get_option( Sync::LOG_KEY );
+
 		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueueScript' ) );
 
 		// \add_action( 'wp_ajax_' . self::ACTION_NAME, array( $this, 'sendStatus' ) );
@@ -101,23 +102,33 @@ class Notices extends Base {
 			return;
 		}
 
+		if( empty( $this->status ) ) {
+			return;
+		}
+
 		$status   = isset( $this->status['get']['response'] ) && 200 === $this->status['get']['response'] ? 'success' : 'warning';
 		$response = isset( $this->status['get']['response'] ) ? isset( $this->status['get']['response'] ) : \esc_html( 'Request Failed', 'wp-action-network-events' );
+		$source = '';
+		$last_run = isset( $this->status['last_run'] ) ? $this->status['last_run'] : '';
 
-		switch ( $this->status['source'] ) {
-			case 'manual':
-				$source = esc_html__( 'Manually Synced', 'wp-action-network-events' );
-				break;
-			case 'import':
-				$source = esc_html__( 'Manually Synced (Full Import)', 'wp-action-network-events' );
-				break;
-			default:
-				$source = esc_html__( 'Auto-synced', 'wp-action-network-events' );
+		if( isset( $this->status['source'] ) ) {
+			switch ( $this->status['source'] ) {
+				case 'manual':
+					$source = esc_html__( 'Manually Synced', 'wp-action-network-events' );
+					break;
+				case 'import':
+					$source = esc_html__( 'Manually Synced (Full Import)', 'wp-action-network-events' );
+					break;
+				default:
+					$source = esc_html__( 'Auto-synced', 'wp-action-network-events' );
+			}
 		}
+
+
 
 		?>
 		<div class="notice notice-<?php echo $status; ?> is-dismissible">
-			<p><?php printf( 'Last %s at %s - Status %s', $source, $this->status['last_run'], $response ); ?></p>
+			<p><?php printf( 'Last %s at %s - Status %s', $source, $last_run, $response ); ?></p>
 			<p><?php print_r( $this->status ); ?></p>
 		</div>
 		<?php

--- a/src/App/General/CustomFields.php
+++ b/src/App/General/CustomFields.php
@@ -46,6 +46,8 @@ class CustomFields extends Base {
 		'an_campaign_id',
 		'internal_name',
 		'hidden',
+		'import_date',
+		'update_date'
 	);
 
 	/**

--- a/src/App/General/CustomFields.php
+++ b/src/App/General/CustomFields.php
@@ -223,7 +223,7 @@ class CustomFields extends Base {
 	 */
 	public function modifyIsAnEvent( $field ) {
 		$field['type']          = 'true_false';
-		$field['label']         = __( 'Action Network Event', 'wp-action-network-events' );
+		$field['label']         = __( 'Sync with Action Network', 'wp-action-network-events' );
 		$field['ui']            = 1;
 		$field['ui_on_text']    = '';
 		$field['ui_off_text']   = '';

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -159,7 +159,7 @@ class Process extends Base {
 			'post_content' => \wp_kses_post( $post->post_content ),
 			'post_status'  => \esc_attr( $post->post_status ),
 			'post_type'    => Event::POST_TYPE['id'],
-			'import_id'    => \esc_attr( $post->an_id ),
+			// 'import_id'    => \esc_attr( $post->an_id ),
 			'meta_input'   => array(
 				'is_an_event'        => 1,
 				'browser_url'        => \esc_url( $post->browser_url ),

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -320,6 +320,7 @@ class Process extends Base {
 			'visibility',
 			'an_campaign_id',
 			'hidden',
+			'update_date',
 		);
 
 		foreach ( $post_fields as $field ) {
@@ -335,6 +336,9 @@ class Process extends Base {
 				error_log( sprintf( 'Existing: %s | New %s', $meta, $incoming->{$field} ) );
 
 				switch ( $field ) {
+					case 'update_date':
+						$differences['meta_input']['update_date'] = date( $this->date_format );
+						break;
 					case 'timezone':
 						$differences['meta_input']['timezone'] = $timezone;
 						break;

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -289,6 +289,10 @@ class Process extends Base {
 	public function getDifferences( object $existing, object $incoming ) : array {
 		$differences = array();
 
+		if ( ! $this->isAnEvent( $existing ) ) {
+			return $differences;
+		}
+
 		$timezone = $this->getTimezone(
 			array(
 				'venue'     => $incoming->location_venue,

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -330,7 +330,7 @@ class Process extends Base {
 		foreach ( $post_fields as $field ) {
 			if ( ! isset( $existing->{$field} ) || ( isset( $existing->{$field} ) && $this->isDifferent( $existing->{$field}, $incoming->{$field} ) ) ) {
 				error_log( sprintf( 'Existing: %s | New %s | Test: ', $existing->{$field}, $incoming->{$field}, $this->isDifferent( $existing->{$field}, $incoming->{$field} ) ) );
-				$differences[ $field ] = $existing->{$field};
+				$differences[ $field ] = $incoming->{$field};
 			}
 		}
 
@@ -350,7 +350,7 @@ class Process extends Base {
 						$differences['meta_input']['location_venue'] = ( ! empty( $incoming->location_venue ) ) ? \esc_attr( $incoming->location_venue ) : 'Virtual';
 						break;
 					default:
-						$differences['meta_input'][ $field ] = $existing->{$field};
+						$differences['meta_input'][ $field ] = $incoming->{$field};
 						break;
 				}
 			}

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -215,7 +215,13 @@ class Process extends Base {
 	 */
 	function updatePost( object $existing, object $incoming ) {
 		$post_id = false;
-		if ( $differences = $this->getDifferences( $existing, $incoming ) ) {
+
+		if ( ! $existing->is_an_event || ! $existing->an_id ) {
+			$this->setLog( 'skipped', $existing->ID );
+			return $post_id;
+		}
+
+		if ( $differences = $this->getDifferences( (object) $existing, $incoming ) ) {
 			$differences['ID'] = $existing->ID;
 			$post_id           = \wp_update_post( $differences );
 

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -387,6 +387,18 @@ class Process extends Base {
 	}
 
 	/**
+	 * Check if is AN event
+	 *
+	 * @since 1.0.1
+	 *
+	 * @param object $post
+	 * @return boolean
+	 */
+	public function isAnEvent( $post ) : bool {
+		return \get_post_meta( $post->ID, 'is_an_event', true );
+	}
+
+	/**
 	 * Check if post has changed
 	 *
 	 * @param object $existing

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -178,6 +178,7 @@ class Process extends Base {
 				'visibility'         => \esc_attr( $post->visibility ),
 				'an_campaign_id'     => ( ! empty( $post->{'action_network:event_campaign_id'} ) ) ? \esc_attr( $post->{'action_network:event_campaign_id'} ) : '',
 				'hidden'             => $post->hidden,
+				'import_date'        => date( $this->date_format ),
 			),
 		);
 

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -271,11 +271,6 @@ class Process extends Base {
 			'post_type'      => Event::POST_TYPE['id'],
 			'meta_query'     => array(
 				array(
-					'key'     => 'is_an_event',
-					'value'   => array( '1', true ),
-					'compare' => 'IN',
-				),
-				array(
 					'key'   => 'an_id',
 					'value' => $record_identifier,
 				),

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -143,7 +143,8 @@ class Process extends Base {
 	 * @return void
 	 */
 	function addPost( $post ) {
-		$post_id  = null;
+		$post_id = null;
+
 		$timezone = $this->getTimezone(
 			array(
 				'venue'     => $post->location_venue,

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -120,8 +120,11 @@ class Process extends Base {
 			$result = $this->addPost( $post );
 		} elseif ( $this->hasChanged( $search_post[0], $post ) ) {
 			$existing_post = $search_post[0];
-			$result        = $this->updatePost( $existing_post, $post );
-			$this->setLog( 'updated[]', $post->an_id );
+			if ( $this->isAnEvent( $existing_post ) ) {
+				$result = $this->updatePost( $existing_post, $post );
+			} else {
+				$this->setLog( 'skipped', $existing_post->ID );
+			}
 		} else {
 			$this->setLog( 'skipped', $post->an_id );
 		}

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -407,7 +407,19 @@ class Process extends Base {
 	 * @return bool
 	 */
 	public function hasChanged( $existing, $incoming ) : bool {
-		return $existing->post_modified < $incoming->post_modified;
+		$import_date   = ( $imported = \get_post_meta( $existing->ID, 'import_date', true ) ) ? date( $this->date_format, strtotime( $imported ) ) : false;
+		$update_date   = ( $updated = \get_post_meta( $existing->ID, 'update_date', true ) ) ? date( $this->date_format, strtotime( $updated ) ) : false;
+		$updated       = $update_date ? $update_date : $import_date;
+		$incoming_date = date( $this->date_format, strtotime( $incoming->post_modified ) );
+		$existing_date = date( $this->date_format, strtotime( $existing->post_modified ) );
+
+		if ( $updated ) {
+			return $incoming_date > $updated;
+		} elseif ( $existing_date ) {
+			return $incoming_date > $existing_date;
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/App/Integration/Process.php
+++ b/src/App/Integration/Process.php
@@ -257,6 +257,11 @@ class Process extends Base {
 			'post_type'      => Event::POST_TYPE['id'],
 			'meta_query'     => array(
 				array(
+					'key'     => 'is_an_event',
+					'value'   => array( '1', true ),
+					'compare' => 'IN',
+				),
+				array(
 					'key'   => 'an_id',
 					'value' => $record_identifier,
 				),
@@ -350,6 +355,11 @@ class Process extends Base {
 			'fields'         => 'ids',
 			'post_type'      => Event::POST_TYPE['id'],
 			'meta_query'     => array(
+				array(
+					'key'     => 'is_an_event',
+					'value'   => array( '1', true ),
+					'compare' => 'IN',
+				),
 				array(
 					'key'   => 'an_id',
 					'value' => $record_identifier,

--- a/src/App/Integration/Sync.php
+++ b/src/App/Integration/Sync.php
@@ -157,7 +157,7 @@ class Sync extends Base {
 		\add_action( 'admin_init', array( $this, 'addCustomCapability' ) );
 		\add_action( 'admin_enqueue_scripts', array( $this, 'enqueueScripts' ) );
 
-		if ( ! function_exists( 'wp_get_current_user' ) ) {
+		if ( ! function_exists( '\wp_get_current_user' ) ) {
 			include ABSPATH . 'wp-includes/pluggable.php';
 		}
 

--- a/wp-action-network-events.php
+++ b/wp-action-network-events.php
@@ -8,7 +8,7 @@
  * that starts the plugin.
  *
  * @link              https://debtcollective.org
- * @since             1.0.0
+ * @since             1.0.1
  * @package           Wp_Action_Network_Events
  *
  * @wordpress-plugin
@@ -62,7 +62,7 @@ function autoloader( $class ) {
  * Rename this for your plugin and update it as you release new versions.
  */
 const PLUGIN_NAME = 'wp-action-network-events';
-const PLUGIN_VERSION = '1.0.0';
+const PLUGIN_VERSION = '1.0.1';
 
 define( 'WPANE_PLUGIN_DIR_PATH', \plugin_dir_path( __FILE__ ) );
 define( 'WPANE_PLUGIN_URL', \plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
Don't sync events that are not marked as `is_an_event`.

ref: https://app.asana.com/0/1199911848001626/1202015125647450/f