### PR TITLE
Pea/events template

### DIFF
--- a/src/App/Admin/Options.php
+++ b/src/App/Admin/Options.php
@@ -410,14 +410,14 @@ class Options extends Base {
 	 * @return void
 	 */
 	public function renderEventArchiveSlugField() {
-		$value = isset( $this->options['archive_slug'] ) ? $this->options['archive_slug'] : 'events';
+		$value = isset( $this->options['archive_slug'] ) ? $this->options['archive_slug'] : false;
 
 		printf(
 			'<input type="text" name="wp_action_network_events_options[archive_slug]" class="regular-text archive_slug_field" placeholder="%s" value="%s">',
-			esc_attr__( 'events', 'wp-action-network-events' ),
+			esc_attr__( '', 'wp-action-network-events' ),
 			esc_attr( $value )
 		);
-		echo '<p class="description">' . __( 'Select slug for the events archive page.', 'wp-action-network-events' ) . '</p>';
+		echo '<p class="description">' . __( 'Select slug for the events archive page. Leave empty to disable event archive.', 'wp-action-network-events' ) . '</p>';
 
 	}
 
@@ -427,14 +427,14 @@ class Options extends Base {
 	 * @return void
 	 */
 	public function renderEventSlugField() {
-		$value = isset( $this->options['event_slug'] ) ? $this->options['event_slug'] : 'event';
+		$value = isset( $this->options['event_slug'] ) ? $this->options['event_slug'] : Event::POST_TYPE['slug'];
 
 		printf(
 			'<input type="text" name="wp_action_network_events_options[event_slug]" class="regular-text event_slug_field" placeholder="%s" value="%s">',
-			esc_attr__( 'event', 'wp-action-network-events' ),
+			esc_attr__( '', 'wp-action-network-events' ),
 			esc_attr( $value )
 		);
-		echo '<p class="description">' . __( 'Select slug for the events archive page.', 'wp-action-network-events' ) . '</p>';
+		echo '<p class="description">' . __( 'Select slug for individual events (e.g. /events/{event-name}).', 'wp-action-network-events' ) . '</p>';
 
 	}
 

--- a/src/App/Blocks/templates/event.php
+++ b/src/App/Blocks/templates/event.php
@@ -18,6 +18,8 @@ $end_datetime = $raw_end_date ? new \DateTime( $raw_end_date ) : null;
 $formatted_start_date = $start_datetime->format( $date_format );
 $formatted_start_time = $start_datetime->format( $time_format );
 $formatted_end_time = $end_datetime ? $end_datetime->format( $time_format ) : null;
+$is_past              = $start_datetime->format( 'Y-m-d' ) < date( 'Y-m-d', time() );
+$class                = $is_past ? \esc_attr( 'past' ) : \esc_attr( 'upcoming' );
 
 /** Get timezone abbreviation */
 $generic_date = new \DateTime( $raw_start_date );
@@ -26,6 +28,7 @@ $timezone_abbr = $generic_date->format( 'T' );
 ?>
 
 <<?php echo $args['tagName']; ?> <?php \post_class( 'event' ); ?>>
+<<?php echo $args['tagName']; ?> <?php \post_class( 'event ' . $class ); ?>>
 
     <a href="<?php echo \esc_url( \get_permalink() ); ?>">
         <?php if( $args['showTags'] && \has_term( '', $taxonomy, $post_id ) ) : 

--- a/src/App/Blocks/templates/event.php
+++ b/src/App/Blocks/templates/event.php
@@ -1,23 +1,23 @@
 <?php
 /**
  * Event Template
- * 
+ *
  * Override this template with one placed in {theme}/template-parts/components/event.php
  */
-$args = $data->args;
-$post_id = $data->id;
-$taxonomy = $data->args['taxonomy'];
-$date_format = $args['dateFormat'];
-$time_format = $args['timeFormat'];
-$default_timezone = \get_option( 'timezone_string' );
-$timezone = ( $tm = \get_post_meta( $post_id, 'timezone', true ) ) ? $tm : $default_timezone;
-$raw_start_date = \get_post_meta( $post_id, 'start_date', true );
-$raw_end_date = \get_post_meta( $post_id, 'end_date', true );
-$start_datetime = new \DateTime( $raw_start_date );
-$end_datetime = $raw_end_date ? new \DateTime( $raw_end_date ) : null;
+$args                 = $data->args;
+$post_id              = $data->id;
+$taxonomy             = $data->args['taxonomy'];
+$date_format          = $args['dateFormat'];
+$time_format          = $args['timeFormat'];
+$default_timezone     = \get_option( 'timezone_string' );
+$timezone             = ( $tm = \get_post_meta( $post_id, 'timezone', true ) ) ? $tm : $default_timezone;
+$raw_start_date       = \get_post_meta( $post_id, 'start_date', true );
+$raw_end_date         = \get_post_meta( $post_id, 'end_date', true );
+$start_datetime       = new \DateTime( $raw_start_date );
+$end_datetime         = $raw_end_date ? new \DateTime( $raw_end_date ) : null;
 $formatted_start_date = $start_datetime->format( $date_format );
 $formatted_start_time = $start_datetime->format( $time_format );
-$formatted_end_time = $end_datetime ? $end_datetime->format( $time_format ) : null;
+$formatted_end_time   = $end_datetime ? $end_datetime->format( $time_format ) : null;
 $is_past              = $start_datetime->format( 'Y-m-d' ) < date( 'Y-m-d', time() );
 $class                = $is_past ? \esc_attr( 'past' ) : \esc_attr( 'upcoming' );
 
@@ -27,50 +27,51 @@ $generic_date->setTimezone( new \DateTimeZone( $timezone ) );
 $timezone_abbr = $generic_date->format( 'T' );
 ?>
 
-<<?php echo $args['tagName']; ?> <?php \post_class( 'event' ); ?>>
 <<?php echo $args['tagName']; ?> <?php \post_class( 'event ' . $class ); ?>>
 
-    <a href="<?php echo \esc_url( \get_permalink() ); ?>">
-        <?php if( $args['showTags'] && \has_term( '', $taxonomy, $post_id ) ) : 
-            $tags = \wp_get_post_terms( $post_id, $taxonomy, [ 'fields' => 'names' ] );
-            ?>
+	<a href="<?php echo \esc_url( \get_permalink() ); ?>">
+		<?php
+		if ( $args['showTags'] && \has_term( '', $taxonomy, $post_id ) ) :
+			$tags = \wp_get_post_terms( $post_id, $taxonomy, array( 'fields' => 'names' ) );
+			?>
 
-            <div class="event__tag">
-                <?php echo \esc_html( $tags[0] ); ?>
-            </div>
+			<div class="event__tag">
+				<?php echo \esc_html( $tags[0] ); ?>
+			</div>
 
-        <?php endif; ?>
+		<?php endif; ?>
 
-        <h3 class="event__title<?php echo !$args['showTitle'] ? ' sr-only' : ''; ?>"><?php the_title(); ?></h3>
-            
-        <?php if( $args['showDate'] ) : ?>
-            
-            <div class="event__date">
-                <time dateTime=<?php echo \esc_attr( $raw_start_date ); ?>><?php echo $formatted_start_date; ?></time>
-            </div>
-            
-        <?php endif; ?>
+		<h3 class="event__title<?php echo ! $args['showTitle'] ? ' sr-only' : ''; ?>"><?php the_title(); ?></h3>
+			
+		<?php if ( $args['showDate'] ) : ?>
+			
+			<div class="event__date">
+				<time dateTime=<?php echo \esc_attr( $raw_start_date ); ?>><?php echo $formatted_start_date; ?></time>
+			</div>
+			
+		<?php endif; ?>
 
-        <?php if( $args['showTime'] ) : ?>
-            
-            <div class="event__time event__time-start">
-                <?php 
-                    printf( '<time dateTime=%1$s>%2$s</time> %3$s <span class="timezone-abbr">%4$s</span>',
-                        \esc_attr( $raw_start_date ),
-                        $formatted_start_time,
-                        ( $formatted_end_time && $args['showEndTime'] ) ? sprintf( '<span class="separator">-</span> <time dateTime=%1$s>%2$s</time>', \esc_attr( $raw_end_date ), $formatted_end_time ) : '',
-                        $timezone_abbr 
-                    ); 
-                ?>
-            </div>
-            
-        <?php endif; ?>
+		<?php if ( $args['showTime'] ) : ?>
+			
+			<div class="event__time event__time-start">
+				<?php
+					printf(
+						'<time dateTime=%1$s>%2$s</time> %3$s <span class="timezone-abbr">%4$s</span>',
+						\esc_attr( $raw_start_date ),
+						$formatted_start_time,
+						( $formatted_end_time && $args['showEndTime'] ) ? sprintf( '<span class="separator">-</span> <time dateTime=%1$s>%2$s</time>', \esc_attr( $raw_end_date ), $formatted_end_time ) : '',
+						$timezone_abbr
+					);
+				?>
+			</div>
+			
+		<?php endif; ?>
 
-        <?php if( $args['showLocation'] && ( $location = \get_post_meta( $post_id, 'location_venue', true ) ) ) : ?>
-            
-            <div class="event__location"><?php echo \esc_attr( $location ); ?></div>
-            
-        <?php endif; ?>
-    </a>
+		<?php if ( $args['showLocation'] && ( $location = \get_post_meta( $post_id, 'location_venue', true ) ) ) : ?>
+			
+			<div class="event__location"><?php echo \esc_attr( $location ); ?></div>
+			
+		<?php endif; ?>
+	</a>
 
 </<?php echo ( $args['tagName'] ); ?>>

--- a/src/App/General/Queries.php
+++ b/src/App/General/Queries.php
@@ -53,6 +53,14 @@ class Queries extends Base {
 	protected $time_diff = '-1 days';
 
 	/**
+	 * Date format
+	 * Used for comparison query
+	 *
+	 * @var string
+	 */
+	protected $date_format = 'Y-m-d';
+
+	/**
 	 * Initialize the class.
 	 *
 	 * @since 1.0.0
@@ -78,7 +86,7 @@ class Queries extends Base {
 	public function getEvents( $scope = 'all', $args = array() ): array {
 		global $post;
 
-		$scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+		// $scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 		$transient_id             = self::QUERY_TRANSIENT . '_objects_' . $scope;
 		$query_transient_duration = isset( $this->options['query_cache_duration'] ) ? (int) $this->options['query_cache_duration'] : (int) 1;
 
@@ -89,13 +97,12 @@ class Queries extends Base {
 			 */
 			$date_time = new \DateTime( $this->time_diff );
 			$date_time->setTimezone( new \DateTimeZone( \wp_timezone_string() ) );
-			$sort = ( $sort = \get_post_meta( get_the_ID(), 'event_sort', true ) ) ? strtoupper( \esc_attr( $sort ) ) : 'DESC';
 
 			$defaults = array(
 				'post_type'      => array( Event::POST_TYPE['id'] ),
 				'posts_per_page' => 500,
 				'orderby'        => 'meta_value',
-				'order'          => $sort,
+				'order'          => 'DESC',
 				'meta_key'       => 'start_date',
 				'meta_type'      => 'DATETIME',
 				'meta_query'     => array(
@@ -140,13 +147,13 @@ class Queries extends Base {
 			if ( 'future' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '>=',
 				);
 			} elseif ( 'past' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '<',
 				);
 			}
@@ -175,7 +182,7 @@ class Queries extends Base {
 	public function getEventIds( $scope = 'all', $args = array() ): array {
 		global $post;
 
-		$scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+		// $scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 		$transient_id             = self::QUERY_TRANSIENT . '_ids_' . $scope;
 		$query_transient_duration = isset( $this->options['query_cache_duration'] ) ? (int) $this->options['query_cache_duration'] : (int) 1;
 
@@ -186,7 +193,7 @@ class Queries extends Base {
 			 */
 			$date_time = new \DateTime( $this->time_diff );
 			$date_time->setTimezone( new \DateTimeZone( \wp_timezone_string() ) );
-			$scope = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+			// $scope = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 
 			$defaults = array(
 				'post_type'      => array( Event::POST_TYPE['id'] ),
@@ -234,13 +241,13 @@ class Queries extends Base {
 			if ( 'future' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '>=',
 				);
 			} elseif ( 'past' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '<',
 				);
 			}


### PR DESCRIPTION
- Update queries
   - Use less specific date format for comparison - All events today are "future"
   - Use `$scope` param only for query
- Add scope class to event
  - `past` or `upcoming`
- Update plugin options
   - Change defaults for `archive` and `slug` settings fields

ref: https://app.asana.com/0/1199911848001626/1202108976201600/f