### PR TITLE
Pea/events fix merge

### DIFF
--- a/src/App/General/Queries.php
+++ b/src/App/General/Queries.php
@@ -86,7 +86,7 @@ class Queries extends Base {
 	public function getEvents( $scope = 'all', $args = array() ): array {
 		global $post;
 
-		$scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+		// $scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 		$transient_id             = self::QUERY_TRANSIENT . '_objects_' . $scope;
 		$query_transient_duration = isset( $this->options['query_cache_duration'] ) ? (int) $this->options['query_cache_duration'] : (int) 1;
 
@@ -182,7 +182,7 @@ class Queries extends Base {
 	public function getEventIds( $scope = 'all', $args = array() ): array {
 		global $post;
 
-		$scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+		// $scope                    = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 		$transient_id             = self::QUERY_TRANSIENT . '_ids_' . $scope;
 		$query_transient_duration = isset( $this->options['query_cache_duration'] ) ? (int) $this->options['query_cache_duration'] : (int) 1;
 
@@ -193,7 +193,7 @@ class Queries extends Base {
 			 */
 			$date_time = new \DateTime( $this->time_diff );
 			$date_time->setTimezone( new \DateTimeZone( \wp_timezone_string() ) );
-			$scope = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
+			// $scope = ( $event_scope = \get_post_meta( \get_the_ID(), 'event_scope', true ) ) ? $event_scope : $scope;
 
 			$defaults = array(
 				'post_type'      => array( Event::POST_TYPE['id'] ),

--- a/src/App/General/Queries.php
+++ b/src/App/General/Queries.php
@@ -97,13 +97,12 @@ class Queries extends Base {
 			 */
 			$date_time = new \DateTime( $this->time_diff );
 			$date_time->setTimezone( new \DateTimeZone( \wp_timezone_string() ) );
-			$sort = ( $sort = \get_post_meta( get_the_ID(), 'event_sort', true ) ) ? strtoupper( \esc_attr( $sort ) ) : 'DESC';
 
 			$defaults = array(
 				'post_type'      => array( Event::POST_TYPE['id'] ),
 				'posts_per_page' => 500,
 				'orderby'        => 'meta_value',
-				'order'          => $sort,
+				'order'          => 'DESC',
 				'meta_key'       => 'start_date',
 				'meta_type'      => 'DATETIME',
 				'meta_query'     => array(

--- a/src/App/General/Queries.php
+++ b/src/App/General/Queries.php
@@ -53,6 +53,14 @@ class Queries extends Base {
 	protected $time_diff = 'now';
 
 	/**
+	 * Date format
+	 * Used for comparison query
+	 *
+	 * @var string
+	 */
+	protected $date_format = 'Y-m-d';
+
+	/**
 	 * Initialize the class.
 	 *
 	 * @since 1.0.0
@@ -140,13 +148,13 @@ class Queries extends Base {
 			if ( 'future' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '>=',
 				);
 			} elseif ( 'past' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '<',
 				);
 			}
@@ -234,13 +242,13 @@ class Queries extends Base {
 			if ( 'future' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '>=',
 				);
 			} elseif ( 'past' === $scope ) {
 				$args['meta_query'][] = array(
 					'key'     => 'start_date',
-					'value'   => $date_time->format( 'c' ),
+					'value'   => $date_time->format( $this->date_format ),
 					'compare' => '<',
 				);
 			}


### PR DESCRIPTION
- Use `$scope` passed as param
- Add simple date format for comparison
- Set default sort
   - Can be overridden by passing a different value to `$args` param